### PR TITLE
[WIP] Add dual-stack support

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,6 +56,8 @@ Usage of kube-router:
       --disable-source-dest-check                     Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
       --enable-cni                                    Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
       --enable-ibgp                                   Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
+      --enable-ipv4                                   Enables IPv4 support (default true)
+      --enable-ipv6                                   Enables IPv6 support (default true)
       --enable-overlay                                When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
       --enable-pod-egress                             SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                                  Enables pprof for debugging performance and memory leak issues.

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/client-go v0.21.3
 	k8s.io/cri-api v0.21.3
 	k8s.io/klog/v2 v2.10.0
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
 )
 
 replace github.com/containerd/containerd => github.com/containerd/containerd v1.5.4 // CVE-2021-32760

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -3,6 +3,8 @@ package controllers
 import (
 	"net"
 
+	"github.com/cloudnativelabs/kube-router/pkg/utils"
+
 	"github.com/coreos/go-iptables/iptables"
 	v1core "k8s.io/api/core/v1"
 )
@@ -10,6 +12,7 @@ import (
 type IPFamilyHandler struct {
 	Family             v1core.IPFamily
 	IptablesCmdHandler *iptables.IPTables
+	IPSetHandler       *utils.IPSet
 	NodeIP             net.IP
 	PodCidr            string
 	BridgeIfName       string

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -1,1 +1,41 @@
 package controllers
+
+import (
+	"net"
+
+	"github.com/coreos/go-iptables/iptables"
+	v1core "k8s.io/api/core/v1"
+)
+
+type IPFamilyHandler struct {
+	Family             v1core.IPFamily
+	IptablesCmdHandler *iptables.IPTables
+	NodeIP             net.IP
+	PodCidr            string
+	BridgeIfName       string
+}
+
+// func NewIPFamilyHandler(family v1core.IPFamily, nodeIP string,
+// 	podCidr string) (*IPFamilyHandler, error) {
+// 	var (
+// 		iptablesCmdHandler *iptables.IPTables
+// 		err                error
+// 	)
+//
+// 	switch family {
+// 	case v1core.IPv4Protocol:
+// 		iptablesCmdHandler, err = iptables.NewWithProtocol(iptables.ProtocolIPv4)
+// 	case v1core.IPv6Protocol:
+// 		iptablesCmdHandler, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+// 	}
+// 	if err != nil {
+// 		return nil, fmt.Errorf("failed to initialize ip6tables executor: %v", err)
+// 	}
+//
+// 	return &IPFamilyHandler{
+// 		Family:             family,
+// 		IptablesCmdHandler: iptablesCmdHandler,
+// 		NodeIP:             nodeIP,
+// 		PodCidr:            podCidr,
+// 	}, nil
+// }

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -9,8 +9,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
+	"github.com/cloudnativelabs/kube-router/pkg/controllers"
 	"github.com/cloudnativelabs/kube-router/pkg/healthcheck"
 	"github.com/cloudnativelabs/kube-router/pkg/metrics"
 	"github.com/cloudnativelabs/kube-router/pkg/options"
@@ -19,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog/v2"
 
+	v1core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -49,6 +52,42 @@ var (
 	}
 )
 
+type ipFamilyHandler struct {
+	iptablesSaveRestore *utils.IPTablesSaveRestore
+
+	*controllers.IPFamilyHandler
+}
+
+func newIPFamilyHandler(family v1core.IPFamily, nodeIP net.IP) (*ipFamilyHandler, error) {
+	var (
+		iptablesCmdHandler *iptables.IPTables
+		err                error
+	)
+
+	iptablesSaveRestore := utils.NewIPTablesSaveRestore(family)
+
+	switch family {
+	case v1core.IPv4Protocol:
+		iptablesCmdHandler, err = iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return nil, err
+		}
+	case v1core.IPv6Protocol:
+		iptablesCmdHandler, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ipFamilyHandler{
+		iptablesSaveRestore: iptablesSaveRestore,
+		IPFamilyHandler: &controllers.IPFamilyHandler{
+			Family:             family,
+			IptablesCmdHandler: iptablesCmdHandler,
+			NodeIP:             nodeIP,
+		},
+	}, nil
+}
+
 // Network policy controller provides both ingress and egress filtering for the pods as per the defined network
 // policies. Two different types of iptables chains are used. Each pod running on the node which either
 // requires ingress or egress filtering gets a pod specific chains. Each network policy has a iptables chain, which
@@ -62,17 +101,21 @@ var (
 
 // NetworkPolicyController struct to hold information required by NetworkPolicyController
 type NetworkPolicyController struct {
-	nodeIP                  net.IP
-	nodeHostName            string
-	serviceClusterIPRange   net.IPNet
-	serviceExternalIPRanges []net.IPNet
-	serviceNodePortRange    string
-	mu                      sync.Mutex
-	syncPeriod              time.Duration
-	MetricsEnabled          bool
-	healthChan              chan<- *healthcheck.ControllerHeartbeat
-	fullSyncRequestChan     chan struct{}
-	ipsetMutex              *sync.Mutex
+	nodeHostName                   string
+	primaryServiceClusterIPRange   net.IPNet
+	secondaryServiceClusterIPRange net.IPNet
+	serviceExternalIPRanges        []net.IPNet
+	serviceNodePortRange           string
+	mu                             sync.Mutex
+	syncPeriod                     time.Duration
+	MetricsEnabled                 bool
+	healthChan                     chan<- *healthcheck.ControllerHeartbeat
+	fullSyncRequestChan            chan struct{}
+	ipsetMutex                     *sync.Mutex
+	enableIPv4                     bool
+	enableIPv6                     bool
+
+	ipFamilyHandlers map[uint16]*ipFamilyHandler
 
 	ipSetHandler *utils.IPSet
 
@@ -251,9 +294,11 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 	}
 
 	npc.filterTableRules.Reset()
-	if err := utils.SaveInto("filter", &npc.filterTableRules); err != nil {
-		klog.Errorf("Aborting sync. Failed to run iptables-save: %v" + err.Error())
-		return
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		if err := ipFamilyHandler.iptablesSaveRestore.SaveInto("filter", &npc.filterTableRules); err != nil {
+			klog.Errorf("Aborting sync. Failed to run iptables-save: %v" + err.Error())
+			return
+		}
 	}
 
 	activePolicyChains, activePolicyIPSets, err := npc.syncNetworkPolicyChains(networkPoliciesInfo, syncVersion)
@@ -274,10 +319,12 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		return
 	}
 
-	if err := utils.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
-		klog.Errorf("Aborting sync. Failed to run iptables-restore: %v\n%s",
-			err.Error(), npc.filterTableRules.String())
-		return
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		if err := ipFamilyHandler.iptablesSaveRestore.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
+			klog.Errorf("Aborting sync. Failed to run iptables-restore: %v\n%s",
+				err.Error(), npc.filterTableRules.String())
+			return
+		}
 	}
 
 	err = npc.cleanupStaleIPSets(activePolicyIPSets)
@@ -298,123 +345,128 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 	const whitelistUDPNodePortsPosition = 3
 	const externalIPPositionAdditive = 4
 
-	iptablesCmdHandler, err := iptables.New()
-	if err != nil {
-		klog.Fatalf("Failed to initialize iptables executor due to %s", err.Error())
-	}
-
-	addUUIDForRuleSpec := func(chain string, ruleSpec *[]string) (string, error) {
-		hash := sha256.Sum256([]byte(chain + strings.Join(*ruleSpec, "")))
-		encoded := base32.StdEncoding.EncodeToString(hash[:])[:16]
-		for idx, part := range *ruleSpec {
-			if part == "--comment" {
-				(*ruleSpec)[idx+1] = (*ruleSpec)[idx+1] + " - " + encoded
-				return encoded, nil
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		addUUIDForRuleSpec := func(chain string, ruleSpec *[]string) (string, error) {
+			hash := sha256.Sum256([]byte(chain + strings.Join(*ruleSpec, "")))
+			encoded := base32.StdEncoding.EncodeToString(hash[:])[:16]
+			for idx, part := range *ruleSpec {
+				if part == "--comment" {
+					(*ruleSpec)[idx+1] = (*ruleSpec)[idx+1] + " - " + encoded
+					return encoded, nil
+				}
 			}
-		}
-		return "", fmt.Errorf("could not find a comment in the ruleSpec string given: %s",
-			strings.Join(*ruleSpec, " "))
-	}
-
-	ensureRuleAtPosition := func(chain string, ruleSpec []string, uuid string, position int) {
-		exists, err := iptablesCmdHandler.Exists("filter", chain, ruleSpec...)
-		if err != nil {
-			klog.Fatalf("Failed to verify rule exists in %s chain due to %s", chain, err.Error())
-		}
-		if !exists {
-			err := iptablesCmdHandler.Insert("filter", chain, position, ruleSpec...)
-			if err != nil {
-				klog.Fatalf("Failed to run iptables command to insert in %s chain %s", chain, err.Error())
-			}
-			return
-		}
-		rules, err := iptablesCmdHandler.List("filter", chain)
-		if err != nil {
-			klog.Fatalf("failed to list rules in filter table %s chain due to %s", chain, err.Error())
+			return "", fmt.Errorf("could not find a comment in the ruleSpec string given: %s",
+				strings.Join(*ruleSpec, " "))
 		}
 
-		var ruleNo, ruleIndexOffset int
-		for i, rule := range rules {
-			rule = strings.Replace(rule, "\"", "", 2) // removes quote from comment string
-			if strings.HasPrefix(rule, "-P") || strings.HasPrefix(rule, "-N") {
-				// if this chain has a default policy, then it will show as rule #1 from iptablesCmdHandler.List so we
-				// need to account for this offset
-				ruleIndexOffset++
-				continue
-			}
-			if strings.Contains(rule, uuid) {
-				// range uses a 0 index, but iptables uses a 1 index so we need to increase ruleNo by 1
-				ruleNo = i + 1 - ruleIndexOffset
-				break
-			}
-		}
-		if ruleNo != position {
-			err = iptablesCmdHandler.Insert("filter", chain, position, ruleSpec...)
+		ensureRuleAtPosition := func(chain string, ruleSpec []string, uuid string, position int) {
+			exists, err := ipFamilyHandler.IptablesCmdHandler.Exists("filter", chain, ruleSpec...)
 			if err != nil {
-				klog.Fatalf("Failed to run iptables command to insert in %s chain %s", chain, err.Error())
+				klog.Fatalf("Failed to verify rule exists in %s chain due to %s", chain, err.Error())
 			}
-			err = iptablesCmdHandler.Delete("filter", chain, strconv.Itoa(ruleNo+1))
+			if !exists {
+				err := ipFamilyHandler.IptablesCmdHandler.Insert("filter", chain, position, ruleSpec...)
+				if err != nil {
+					klog.Fatalf("Failed to run iptables command to insert in %s chain %s", chain, err.Error())
+				}
+				return
+			}
+			rules, err := ipFamilyHandler.IptablesCmdHandler.List("filter", chain)
 			if err != nil {
-				klog.Fatalf("Failed to delete incorrect rule in %s chain due to %s", chain, err.Error())
+				klog.Fatalf("failed to list rules in filter table %s chain due to %s", chain, err.Error())
 			}
-		}
-	}
 
-	for builtinChain, customChain := range defaultChains {
-		exists, err := iptablesCmdHandler.ChainExists("filter", customChain)
-		if err != nil {
-			klog.Fatalf("failed to check for the existence of chain %s, error: %v", customChain, err)
-		}
-		if !exists {
-			err = iptablesCmdHandler.NewChain("filter", customChain)
-			if err != nil {
-				klog.Fatalf("failed to run iptables command to create %s chain due to %s", customChain,
-					err.Error())
+			var ruleNo, ruleIndexOffset int
+			for i, rule := range rules {
+				rule = strings.Replace(rule, "\"", "", 2) // removes quote from comment string
+				if strings.HasPrefix(rule, "-P") || strings.HasPrefix(rule, "-N") {
+					// if this chain has a default policy, then it will show as rule #1 from iptablesCmdHandler.List so we
+					// need to account for this offset
+					ruleIndexOffset++
+					continue
+				}
+				if strings.Contains(rule, uuid) {
+					// range uses a 0 index, but iptables uses a 1 index so we need to increase ruleNo by 1
+					ruleNo = i + 1 - ruleIndexOffset
+					break
+				}
+			}
+			if ruleNo != position {
+				err = ipFamilyHandler.IptablesCmdHandler.Insert("filter", chain, position, ruleSpec...)
+				if err != nil {
+					klog.Fatalf("Failed to run iptables command to insert in %s chain %s", chain, err.Error())
+				}
+				err = ipFamilyHandler.IptablesCmdHandler.Delete("filter", chain, strconv.Itoa(ruleNo+1))
+				if err != nil {
+					klog.Fatalf("Failed to delete incorrect rule in %s chain due to %s", chain, err.Error())
+				}
 			}
 		}
-		args := []string{"-m", "comment", "--comment", "kube-router netpol", "-j", customChain}
-		uuid, err := addUUIDForRuleSpec(builtinChain, &args)
+
+		for builtinChain, customChain := range defaultChains {
+			exists, err := ipFamilyHandler.IptablesCmdHandler.ChainExists("filter", customChain)
+			if err != nil {
+				klog.Fatalf("failed to check for the existence of chain %s, error: %v", customChain, err)
+			}
+			if !exists {
+				err = ipFamilyHandler.IptablesCmdHandler.NewChain("filter", customChain)
+				if err != nil {
+					klog.Fatalf("failed to run iptables command to create %s chain due to %s", customChain,
+						err.Error())
+				}
+			}
+			args := []string{"-m", "comment", "--comment", "kube-router netpol", "-j", customChain}
+			uuid, err := addUUIDForRuleSpec(builtinChain, &args)
+			if err != nil {
+				klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+			}
+			ensureRuleAtPosition(builtinChain, args, uuid, 1)
+		}
+
+		whitelistPrimaryServiceVips := []string{"-m", "comment", "--comment", "allow traffic to primary cluster IP range",
+			"-d", npc.primaryServiceClusterIPRange.String(), "-j", "RETURN"}
+		uuid, err := addUUIDForRuleSpec(kubeInputChainName, &whitelistPrimaryServiceVips)
 		if err != nil {
 			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
 		}
-		ensureRuleAtPosition(builtinChain, args, uuid, 1)
-	}
+		ensureRuleAtPosition(kubeInputChainName, whitelistPrimaryServiceVips, uuid, serviceVIPPosition)
 
-	whitelistServiceVips := []string{"-m", "comment", "--comment", "allow traffic to cluster IP", "-d",
-		npc.serviceClusterIPRange.String(), "-j", "RETURN"}
-	uuid, err := addUUIDForRuleSpec(kubeInputChainName, &whitelistServiceVips)
-	if err != nil {
-		klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
-	}
-	ensureRuleAtPosition(kubeInputChainName, whitelistServiceVips, uuid, serviceVIPPosition)
-
-	whitelistTCPNodeports := []string{"-p", "tcp", "-m", "comment", "--comment",
-		"allow LOCAL TCP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
-		"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
-	uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistTCPNodeports)
-	if err != nil {
-		klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
-	}
-	ensureRuleAtPosition(kubeInputChainName, whitelistTCPNodeports, uuid, whitelistTCPNodePortsPosition)
-
-	whitelistUDPNodeports := []string{"-p", "udp", "-m", "comment", "--comment",
-		"allow LOCAL UDP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
-		"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
-	uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistUDPNodeports)
-	if err != nil {
-		klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
-	}
-	ensureRuleAtPosition(kubeInputChainName, whitelistUDPNodeports, uuid, whitelistUDPNodePortsPosition)
-
-	for externalIPIndex, externalIPRange := range npc.serviceExternalIPRanges {
-		whitelistServiceVips := []string{"-m", "comment", "--comment",
-			"allow traffic to external IP range: " + externalIPRange.String(), "-d", externalIPRange.String(),
-			"-j", "RETURN"}
-		uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistServiceVips)
+		whitelistSecondaryServiceVips := []string{"-m", "comment", "--comment", "allow traffic to primary cluster IP range",
+			"-d", npc.secondaryServiceClusterIPRange.String(), "-j", "RETURN"}
+		uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistSecondaryServiceVips)
 		if err != nil {
 			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
 		}
-		ensureRuleAtPosition(kubeInputChainName, whitelistServiceVips, uuid, externalIPIndex+externalIPPositionAdditive)
+		ensureRuleAtPosition(kubeInputChainName, whitelistSecondaryServiceVips, uuid, serviceVIPPosition)
+
+		whitelistTCPNodeports := []string{"-p", "tcp", "-m", "comment", "--comment",
+			"allow LOCAL TCP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
+			"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
+		uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistTCPNodeports)
+		if err != nil {
+			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+		}
+		ensureRuleAtPosition(kubeInputChainName, whitelistTCPNodeports, uuid, whitelistTCPNodePortsPosition)
+
+		whitelistUDPNodeports := []string{"-p", "udp", "-m", "comment", "--comment",
+			"allow LOCAL UDP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
+			"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
+		uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistUDPNodeports)
+		if err != nil {
+			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+		}
+		ensureRuleAtPosition(kubeInputChainName, whitelistUDPNodeports, uuid, whitelistUDPNodePortsPosition)
+
+		for externalIPIndex, externalIPRange := range npc.serviceExternalIPRanges {
+			whitelistServiceVips := []string{"-m", "comment", "--comment",
+				"allow traffic to external IP range: " + externalIPRange.String(), "-d", externalIPRange.String(),
+				"-j", "RETURN"}
+			uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistServiceVips)
+			if err != nil {
+				klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+			}
+			ensureRuleAtPosition(kubeInputChainName, whitelistServiceVips, uuid, externalIPIndex+externalIPPositionAdditive)
+		}
 	}
 }
 
@@ -431,31 +483,27 @@ func (npc *NetworkPolicyController) ensureExplicitAccept() {
 
 // Creates custom chains KUBE-NWPLCY-DEFAULT
 func (npc *NetworkPolicyController) ensureDefaultNetworkPolicyChain() {
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		markArgs := make([]string, 0)
+		markComment := "rule to mark traffic matching a network policy"
+		markArgs = append(markArgs, "-j", "MARK", "-m", "comment", "--comment", markComment,
+			"--set-xmark", "0x10000/0x10000")
 
-	iptablesCmdHandler, err := iptables.New()
-	if err != nil {
-		klog.Fatalf("Failed to initialize iptables executor due to %s", err.Error())
-	}
-
-	markArgs := make([]string, 0)
-	markComment := "rule to mark traffic matching a network policy"
-	markArgs = append(markArgs, "-j", "MARK", "-m", "comment", "--comment", markComment,
-		"--set-xmark", "0x10000/0x10000")
-
-	exists, err := iptablesCmdHandler.ChainExists("filter", kubeDefaultNetpolChain)
-	if err != nil {
-		klog.Fatalf("failed to check for the existence of chain %s, error: %v", kubeDefaultNetpolChain, err)
-	}
-	if !exists {
-		err = iptablesCmdHandler.NewChain("filter", kubeDefaultNetpolChain)
+		exists, err := ipFamilyHandler.IptablesCmdHandler.ChainExists("filter", kubeDefaultNetpolChain)
 		if err != nil {
-			klog.Fatalf("failed to run iptables command to create %s chain due to %s",
-				kubeDefaultNetpolChain, err.Error())
+			klog.Fatalf("failed to check for the existence of chain %s, error: %v", kubeDefaultNetpolChain, err)
 		}
-	}
-	err = iptablesCmdHandler.AppendUnique("filter", kubeDefaultNetpolChain, markArgs...)
-	if err != nil {
-		klog.Fatalf("Failed to run iptables command: %s", err.Error())
+		if !exists {
+			err = ipFamilyHandler.IptablesCmdHandler.NewChain("filter", kubeDefaultNetpolChain)
+			if err != nil {
+				klog.Fatalf("failed to run iptables command to create %s chain due to %s",
+					kubeDefaultNetpolChain, err.Error())
+			}
+		}
+		err = ipFamilyHandler.IptablesCmdHandler.AppendUnique("filter", kubeDefaultNetpolChain, markArgs...)
+		if err != nil {
+			klog.Fatalf("Failed to run iptables command: %s", err.Error())
+		}
 	}
 }
 
@@ -465,16 +513,15 @@ func (npc *NetworkPolicyController) cleanupStaleRules(activePolicyChains, active
 	cleanupPodFwChains := make([]string, 0)
 	cleanupPolicyChains := make([]string, 0)
 
-	// initialize tool sets for working with iptables and ipset
 	iptablesCmdHandler, err := iptables.New()
 	if err != nil {
-		return fmt.Errorf("failed to initialize iptables command executor due to %s", err.Error())
+		return fmt.Errorf("failed to initialize iptables command executor due to %w", err)
 	}
 
 	// find iptables chains and ipsets that are no longer used by comparing current to the active maps we were passed
 	chains, err := iptablesCmdHandler.ListChains("filter")
 	if err != nil {
-		return fmt.Errorf("unable to list chains: %s", err)
+		return fmt.Errorf("unable to list chains: %w", err)
 	}
 	for _, chain := range chains {
 		if strings.HasPrefix(chain, kubeNetworkPolicyChainPrefix) {
@@ -545,8 +592,6 @@ func (npc *NetworkPolicyController) cleanupStaleRules(activePolicyChains, active
 }
 
 func (npc *NetworkPolicyController) cleanupStaleIPSets(activePolicyIPSets map[string]bool) error {
-	cleanupPolicyIPSets := make([]*utils.Set, 0)
-
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a
 	// single goroutine where there is no need for locking
@@ -560,27 +605,31 @@ func (npc *NetworkPolicyController) cleanupStaleIPSets(activePolicyIPSets map[st
 		}()
 	}
 
-	ipsets, err := utils.NewIPSet(false)
-	if err != nil {
-		return fmt.Errorf("failed to create ipsets command executor due to %s", err.Error())
-	}
-	err = ipsets.Save()
-	if err != nil {
-		klog.Fatalf("failed to initialize ipsets command executor due to %s", err.Error())
-	}
-	for _, set := range ipsets.Sets {
-		if strings.HasPrefix(set.Name, kubeSourceIPSetPrefix) ||
-			strings.HasPrefix(set.Name, kubeDestinationIPSetPrefix) {
-			if _, ok := activePolicyIPSets[set.Name]; !ok {
-				cleanupPolicyIPSets = append(cleanupPolicyIPSets, set)
+	for ipFamily := range npc.ipFamilyHandlers {
+		cleanupPolicyIPSets := make([]*utils.Set, 0)
+
+		ipsets, err := utils.NewIPSet(ipFamily)
+		if err != nil {
+			return fmt.Errorf("failed to create ipsets command executor due to %w", err)
+		}
+		err = ipsets.Save()
+		if err != nil {
+			klog.Fatalf("failed to initialize ipsets command executor due to %s", err.Error())
+		}
+		for _, set := range ipsets.Sets {
+			if strings.HasPrefix(set.Name, kubeSourceIPSetPrefix) ||
+				strings.HasPrefix(set.Name, kubeDestinationIPSetPrefix) {
+				if _, ok := activePolicyIPSets[set.Name]; !ok {
+					cleanupPolicyIPSets = append(cleanupPolicyIPSets, set)
+				}
 			}
 		}
-	}
-	// cleanup network policy ipsets
-	for _, set := range cleanupPolicyIPSets {
-		err = set.Destroy()
-		if err != nil {
-			return fmt.Errorf("failed to delete ipset %s due to %s", set.Name, err)
+		// cleanup network policy ipsets
+		for _, set := range cleanupPolicyIPSets {
+			err = set.Destroy()
+			if err != nil {
+				return fmt.Errorf("failed to delete ipset %s due to %s", set.Name, err)
+			}
 		}
 	}
 	return nil
@@ -592,9 +641,11 @@ func (npc *NetworkPolicyController) Cleanup() {
 
 	var emptySet map[string]bool
 	// Take a dump (iptables-save) of the current filter table for cleanupStaleRules() to work on
-	if err := utils.SaveInto("filter", &npc.filterTableRules); err != nil {
-		klog.Errorf("error encountered attempting to list iptables rules for cleanup: %v", err)
-		return
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		if err := ipFamilyHandler.iptablesSaveRestore.SaveInto("filter", &npc.filterTableRules); err != nil {
+			klog.Errorf("error encountered attempting to list iptables rules for cleanup: %v", err)
+			return
+		}
 	}
 	// Run cleanupStaleRules() to get rid of most of the kube-router rules (this is the same logic that runs as
 	// part NPC's runtime loop). Setting the last parameter to true causes even the default chains are removed.
@@ -604,10 +655,12 @@ func (npc *NetworkPolicyController) Cleanup() {
 		return
 	}
 	// Restore (iptables-restore) npc's cleaned up version of the iptables filter chain
-	if err = utils.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
-		klog.Errorf(
-			"error encountered while loading running iptables-restore: %v\n%s", err,
-			npc.filterTableRules.String())
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		if err = ipFamilyHandler.iptablesSaveRestore.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
+			klog.Errorf(
+				"error encountered while loading running iptables-restore: %v\n%s", err,
+				npc.filterTableRules.String())
+		}
 	}
 
 	// Cleanup ipsets
@@ -633,11 +686,32 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	npc.fullSyncRequestChan = make(chan struct{}, 1)
 
 	// Validate and parse ClusterIP service range
-	_, ipnet, err := net.ParseCIDR(config.ClusterIPCIDR)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: %s", err.Error())
+	if config.ClusterIPCIDR == "" {
+		return nil, fmt.Errorf("parameter --service-cluster-ip is empty")
 	}
-	npc.serviceClusterIPRange = *ipnet
+	clusterIPCIDRList := strings.Split(config.ClusterIPCIDR, ",")
+
+	if len(clusterIPCIDRList) == 0 {
+		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter, the list is empty")
+	}
+
+	_, primaryIpnet, err := net.ParseCIDR(clusterIPCIDRList[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: %w", err)
+	}
+	npc.primaryServiceClusterIPRange = *primaryIpnet
+
+	if len(clusterIPCIDRList) > 1 {
+		_, secondaryIpnet, err := net.ParseCIDR(clusterIPCIDRList[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: %v", err)
+		}
+		npc.secondaryServiceClusterIPRange = *secondaryIpnet
+	}
+	if len(clusterIPCIDRList) > 2 {
+		return nil, fmt.Errorf("too many CIDRs provided in --service-cluster-ip-range parameter, only two " +
+			"addresses are allowed at once for dual-stack")
+	}
 
 	// Validate and parse NodePort range
 	if npc.serviceNodePortRange, err = validateNodePortRange(config.NodePortRange); err != nil {
@@ -672,11 +746,30 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 
 	npc.nodeHostName = node.Name
 
-	nodeIP, err := utils.GetNodeIP(node)
+	npc.enableIPv4 = config.EnableIPv4
+	npc.enableIPv6 = config.EnableIPv6
+
+	nodeIPv4, nodeIPv6, err := utils.GetNodeIP(node, npc.enableIPv4, npc.enableIPv6)
 	if err != nil {
 		return nil, err
 	}
-	npc.nodeIP = nodeIP
+	// npc.nodeIPv4 = nodeIPv4
+	// npc.nodeIPv6 = nodeIPv6
+	npc.ipFamilyHandlers = make(map[uint16]*ipFamilyHandler)
+	if npc.enableIPv4 {
+		ipv4Handler, err := newIPFamilyHandler(v1core.IPv4Protocol, nodeIPv4)
+		if err != nil {
+			return nil, err
+		}
+		npc.ipFamilyHandlers[syscall.AF_INET] = ipv4Handler
+	}
+	if npc.enableIPv6 {
+		ipv6Handler, err := newIPFamilyHandler(v1core.IPv6Protocol, nodeIPv6)
+		if err != nil {
+			return nil, err
+		}
+		npc.ipFamilyHandlers[syscall.AF_INET6] = ipv6Handler
+	}
 
 	npc.podLister = podInformer.GetIndexer()
 	npc.PodEventHandler = npc.newPodEventHandler()

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -137,14 +139,14 @@ func tNewPodNamespaceMapFromTC(target map[string]string) tPodNamespaceMap {
 func tCreateFakePods(t *testing.T, podInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer) {
 	podNamespaceMap := make(tPodNamespaceMap)
 	pods := []podInfo{
-		{name: "Aa", labels: labels.Set{"app": "a"}, namespace: "nsA", ip: "1.1"},
-		{name: "Aaa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsA", ip: "1.2"},
-		{name: "Aab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsA", ip: "1.3"},
-		{name: "Aac", labels: labels.Set{"app": "a", "component": "c"}, namespace: "nsA", ip: "1.4"},
-		{name: "Ba", labels: labels.Set{"app": "a"}, namespace: "nsB", ip: "2.1"},
-		{name: "Baa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsB", ip: "2.2"},
-		{name: "Bab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsB", ip: "2.3"},
-		{name: "Ca", labels: labels.Set{"app": "a"}, namespace: "nsC", ip: "3.1"},
+		{name: "Aa", labels: labels.Set{"app": "a"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.1.1.1"}}},
+		{name: "Aaa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.2.3.4"}}},
+		{name: "Aab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.3.2.2"}}},
+		{name: "Aac", labels: labels.Set{"app": "a", "component": "c"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.4.2.2"}}},
+		{name: "Ba", labels: labels.Set{"app": "a"}, namespace: "nsB", ips: []v1.PodIP{{IP: "2.1.1.1"}}},
+		{name: "Baa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsB", ips: []v1.PodIP{{IP: "2.2.2.2"}}},
+		{name: "Bab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsB", ips: []v1.PodIP{{IP: "2.3.2.2"}}},
+		{name: "Ca", labels: labels.Set{"app": "a"}, namespace: "nsC", ips: []v1.PodIP{{IP: "3.1"}}},
 	}
 	namespaces := []tNamespaceMeta{
 		{name: "nsA", labels: labels.Set{"name": "a", "team": "a"}},
@@ -155,7 +157,8 @@ func tCreateFakePods(t *testing.T, podInformer cache.SharedIndexInformer, nsInfo
 	ipsUsed := make(map[string]bool)
 	for _, pod := range pods {
 		podNamespaceMap.addPod(pod)
-		ipaddr := "1.1." + pod.ip
+		// TODO: test multiple IPs
+		ipaddr := pod.ips[0].IP
 		if ipsUsed[ipaddr] {
 			t.Fatalf("there is another pod with the same Ip address %s as this pod %s namespace %s",
 				ipaddr, pod.name, pod.name)
@@ -190,6 +193,11 @@ func newUneventfulNetworkPolicyController(podInformer cache.SharedIndexInformer,
 
 	npc := NetworkPolicyController{}
 	npc.syncPeriod = time.Hour
+
+	// TODO: Handle both IP families
+	npc.ipFamilyHandlers = make(map[uint16]*ipFamilyHandler)
+	ipv4Handler, _ := newIPFamilyHandler(v1.IPv4Protocol, net.IPv4(10, 10, 10, 10))
+	npc.ipFamilyHandlers[syscall.AF_INET] = ipv4Handler
 
 	npc.nodeHostName = "node"
 	// npc.nodeIPv4 = net.IPv4(10, 10, 10, 10)
@@ -538,38 +546,39 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 		if err != nil {
 			t.Errorf("Problems building policies: %s", err)
 		}
-		for _, np := range netpols {
-			fmt.Printf(np.policyType)
-			if np.policyType == kubeEgressPolicyType || np.policyType == kubeBothPolicyType {
-				err = krNetPol.processEgressRules(np, "", nil, "1")
-				if err != nil {
-					t.Errorf("Error syncing the rules: %s", err)
+		for _, ipFamilyHandler := range krNetPol.ipFamilyHandlers {
+			for _, np := range netpols {
+				fmt.Printf(np.policyType)
+				if np.policyType == kubeEgressPolicyType || np.policyType == kubeBothPolicyType {
+					err = krNetPol.processEgressRules(np, "", nil, "1", ipFamilyHandler)
+					if err != nil {
+						t.Errorf("Error syncing the rules: %s", err)
+					}
+				}
+				if np.policyType == kubeIngressPolicyType || np.policyType == kubeBothPolicyType {
+					err = krNetPol.processIngressRules(np, "", nil, "1", ipFamilyHandler)
+					if err != nil {
+						t.Errorf("Error syncing the rules: %s", err)
+					}
 				}
 			}
-			if np.policyType == kubeIngressPolicyType || np.policyType == kubeBothPolicyType {
-				err = krNetPol.processIngressRules(np, "", nil, "1")
-				if err != nil {
-					t.Errorf("Error syncing the rules: %s", err)
-				}
-			}
-		}
 
-		if !bytes.Equal([]byte(test.expectedRule), krNetPol.filterTableRules.Bytes()) {
-			t.Errorf("Invalid rule %s created:\nExpected:\n%s \nGot:\n%s", test.name, test.expectedRule, krNetPol.filterTableRules.String())
-		}
-		key := fmt.Sprintf("%s/%s", test.netpol.namespace, test.netpol.name)
-		obj, exists, err := krNetPol.npLister.GetByKey(key)
-		if err != nil {
-			t.Errorf("Failed to get Netpol from store: %s", err)
-		}
-		if exists {
-			err = krNetPol.npLister.Delete(obj)
+			if !bytes.Equal([]byte(test.expectedRule), ipFamilyHandler.filterTableRules.Bytes()) {
+				t.Errorf("Invalid rule %s created:\nExpected:\n%s \nGot:\n%s", test.name, test.expectedRule, ipFamilyHandler.filterTableRules.String())
+			}
+			key := fmt.Sprintf("%s/%s", test.netpol.namespace, test.netpol.name)
+			obj, exists, err := krNetPol.npLister.GetByKey(key)
 			if err != nil {
-				t.Errorf("Failed to remove Netpol from store: %s", err)
+				t.Errorf("Failed to get Netpol from store: %s", err)
 			}
+			if exists {
+				err = krNetPol.npLister.Delete(obj)
+				if err != nil {
+					t.Errorf("Failed to remove Netpol from store: %s", err)
+				}
+			}
+			ipFamilyHandler.filterTableRules.Reset()
 		}
-		krNetPol.filterTableRules.Reset()
-
 	}
 
 }

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -79,39 +79,44 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 	activePodFwChains := make(map[string]bool)
 
 	dropUnmarkedTrafficRules := func(podName, podNamespace, podFwChainName string) {
-		// add rule to log the packets that will be dropped due to network policy enforcement
-		comment := "\"rule to log dropped traffic POD name:" + podName + " namespace: " + podNamespace + "\""
-		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
-			"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG",
-			"--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
-		// This used to be AppendUnique when we were using iptables directly, this checks to make sure we didn't drop
-		// unmarked for this chain already
-		if strings.Contains(npc.filterTableRules.String(), strings.Join(args, " ")) {
-			return
+		for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+			// add rule to log the packets that will be dropped due to network policy enforcement
+			comment := "\"rule to log dropped traffic POD name:" + podName + " namespace: " + podNamespace + "\""
+			args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
+				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG",
+				"--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
+			// This used to be AppendUnique when we were using iptables directly, this checks to make sure we didn't drop
+			// unmarked for this chain already
+			if strings.Contains(ipFamilyHandler.filterTableRules.String(), strings.Join(args, " ")) {
+				return
+			}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+
+			// add rule to DROP if no applicable network policy permits the traffic
+			comment = "\"rule to REJECT traffic destined for POD name:" + podName + " namespace: " + podNamespace + "\""
+			args = []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
+				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "REJECT", "\n"}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+
+			// reset mark to let traffic pass through rest of the chains
+			args = []string{"-A", podFwChainName, "-j", "MARK", "--set-mark", "0/0x10000", "\n"}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
 		}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-		// add rule to DROP if no applicable network policy permits the traffic
-		comment = "\"rule to REJECT traffic destined for POD name:" + podName + " namespace: " + podNamespace + "\""
-		args = []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
-			"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "REJECT", "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-		// reset mark to let traffic pass through rest of the chains
-		args = []string{"-A", podFwChainName, "-j", "MARK", "--set-mark", "0/0x10000", "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
 	}
 
 	// loop through the pods running on the node
 	allLocalPods := make(map[string]podInfo)
 	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
 		npc.getLocalPods(allLocalPods, ipFamilyHandler.NodeIP.String())
+		break
 	}
 	for _, pod := range allLocalPods {
 
 		// ensure pod specific firewall chain exist for all the pods that need ingress firewall
 		podFwChainName := podFirewallChainName(pod.namespace, pod.name, version)
-		npc.filterTableRules.WriteString(":" + podFwChainName + "\n")
+		for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+			ipFamilyHandler.filterTableRules.WriteString(":" + podFwChainName + "\n")
+		}
 
 		activePodFwChains[podFwChainName] = true
 
@@ -126,12 +131,14 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 
 		dropUnmarkedTrafficRules(pod.name, pod.namespace, podFwChainName)
 
-		// set mark to indicate traffic from/to the pod passed network policies.
-		// Mark will be checked to explicitly ACCEPT the traffic
-		comment := "\"set mark to ACCEPT traffic that comply to network policies\""
-		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
-			"-j", "MARK", "--set-mark", "0x20000/0x20000", "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
+		for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+			// set mark to indicate traffic from/to the pod passed network policies.
+			// Mark will be checked to explicitly ACCEPT the traffic
+			comment := "\"set mark to ACCEPT traffic that comply to network policies\""
+			args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
+				"-j", "MARK", "--set-mark", "0x20000/0x20000", "\n"}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+		}
 	}
 
 	return activePodFwChains
@@ -144,111 +151,140 @@ func (npc *NetworkPolicyController) setupPodNetpolRules(pod podInfo, podFwChainN
 	hasIngressPolicy := false
 	hasEgressPolicy := false
 
-	// add entries in pod firewall to run through applicable network policies
-	for _, policy := range networkPoliciesInfo {
-		if _, ok := policy.targetPods[pod.ip]; !ok {
-			continue
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		var ip string
+		switch ipFamilyHandler.Family {
+		case api.IPv4Protocol:
+			ip, _ = getPodIPv4Address(pod)
+		case api.IPv6Protocol:
+			ip, _ = getPodIPv6Address(pod)
 		}
-		comment := "\"run through nw policy " + policy.name + "\""
-		policyChainName := networkPolicyChainName(policy.namespace, policy.name, version)
-		var args []string
-		switch policy.policyType {
-		case kubeBothPolicyType:
-			hasIngressPolicy = true
-			hasEgressPolicy = true
-			args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-				"-j", policyChainName, "\n"}
-		case kubeIngressPolicyType:
-			hasIngressPolicy = true
-			args = []string{"-I", podFwChainName, "1", "-d", pod.ip, "-m", "comment", "--comment", comment,
-				"-j", policyChainName, "\n"}
-		case kubeEgressPolicyType:
-			hasEgressPolicy = true
-			args = []string{"-I", podFwChainName, "1", "-s", pod.ip, "-m", "comment", "--comment", comment,
-				"-j", policyChainName, "\n"}
+		// add entries in pod firewall to run through applicable network policies
+		for _, policy := range networkPoliciesInfo {
+			// TODO: Take the ipv4 address, pod.ips[0] is not good
+			if _, ok := policy.targetPods[pod.ips[0].IP]; !ok {
+				continue
+			}
+			comment := "\"run through nw policy " + policy.name + "\""
+			policyChainName := networkPolicyChainName(policy.namespace, policy.name, version)
+			var args []string
+			switch policy.policyType {
+			case kubeBothPolicyType:
+				hasIngressPolicy = true
+				hasEgressPolicy = true
+				args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
+					"-j", policyChainName, "\n"}
+			case kubeIngressPolicyType:
+				hasIngressPolicy = true
+				args = []string{"-I", podFwChainName, "1", "-d", ip, "-m", "comment", "--comment", comment,
+					"-j", policyChainName, "\n"}
+			case kubeEgressPolicyType:
+				hasEgressPolicy = true
+				args = []string{"-I", podFwChainName, "1", "-s", ip, "-m", "comment", "--comment", comment,
+					"-j", policyChainName, "\n"}
+			}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
 		}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
+
+		// if pod does not have any network policy which applies rules for pod's ingress traffic
+		// then apply default network policy
+		if !hasIngressPolicy {
+			comment := "\"run through default ingress network policy  chain\""
+			args := []string{"-I", podFwChainName, "1", "-d", ip, "-m", "comment", "--comment", comment,
+				"-j", kubeDefaultNetpolChain, "\n"}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+		}
+
+		// if pod does not have any network policy which applies rules for pod's egress traffic
+		// then apply default network policy
+		if !hasEgressPolicy {
+			comment := "\"run through default egress network policy  chain\""
+			args := []string{"-I", podFwChainName, "1", "-s", ip, "-m", "comment", "--comment", comment,
+				"-j", kubeDefaultNetpolChain, "\n"}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+		}
+
+		comment := "\"rule to permit the traffic traffic to pods when source is the pod's local node\""
+		args := []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
+			"-m", "addrtype", "--src-type", "LOCAL", "-d", ip, "-j", "ACCEPT", "\n"}
+		ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+
+		// ensure statefull firewall that permits RELATED,ESTABLISHED traffic from/to the pod
+		comment = "\"rule for stateful firewall for pod\""
+		args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
+			"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT", "\n"}
+		ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
 	}
-
-	// if pod does not have any network policy which applies rules for pod's ingress traffic
-	// then apply default network policy
-	if !hasIngressPolicy {
-		comment := "\"run through default ingress network policy  chain\""
-		args := []string{"-I", podFwChainName, "1", "-d", pod.ip, "-m", "comment", "--comment", comment,
-			"-j", kubeDefaultNetpolChain, "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-	}
-
-	// if pod does not have any network policy which applies rules for pod's egress traffic
-	// then apply default network policy
-	if !hasEgressPolicy {
-		comment := "\"run through default egress network policy  chain\""
-		args := []string{"-I", podFwChainName, "1", "-s", pod.ip, "-m", "comment", "--comment", comment,
-			"-j", kubeDefaultNetpolChain, "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-	}
-
-	comment := "\"rule to permit the traffic traffic to pods when source is the pod's local node\""
-	args := []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-		"-m", "addrtype", "--src-type", "LOCAL", "-d", pod.ip, "-j", "ACCEPT", "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-	// ensure statefull firewall that permits RELATED,ESTABLISHED traffic from/to the pod
-	comment = "\"rule for stateful firewall for pod\""
-	args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-		"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT", "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
-
 }
 
 func (npc *NetworkPolicyController) interceptPodInboundTraffic(pod podInfo, podFwChainName string) {
-	// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
-	// this rule applies to the traffic getting routed (coming for other node pods)
-	comment := "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
-		" to chain " + podFwChainName + "\""
-	args := []string{"-A", kubeForwardChainName, "-m", "comment", "--comment", comment, "-d", pod.ip,
-		"-j", podFwChainName + "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		var ip string
+		switch ipFamilyHandler.Family {
+		case api.IPv4Protocol:
+			ip, _ = getPodIPv4Address(pod)
+		case api.IPv6Protocol:
+			ip, _ = getPodIPv6Address(pod)
+		}
 
-	// ensure there is rule in filter table and OUTPUT chain to jump to pod specific firewall chain
-	// this rule applies to the traffic from a pod getting routed back to another pod on same node by service proxy
-	args = []string{"-A", kubeOutputChainName, "-m", "comment", "--comment", comment, "-d", pod.ip,
-		"-j", podFwChainName + "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
+		// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
+		// this rule applies to the traffic getting routed (coming for other node pods)
+		comment := "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
+			" to chain " + podFwChainName + "\""
+		args := []string{"-A", kubeForwardChainName, "-m", "comment", "--comment", comment, "-d", ip,
+			"-j", podFwChainName + "\n"}
+		ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
 
-	// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
-	// this rule applies to the traffic getting switched (coming for same node pods)
-	comment = "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
-		" to chain " + podFwChainName + "\""
-	args = []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
-		"-m", "comment", "--comment", comment,
-		"-d", pod.ip,
-		"-j", podFwChainName, "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
+		// ensure there is rule in filter table and OUTPUT chain to jump to pod specific firewall chain
+		// this rule applies to the traffic from a pod getting routed back to another pod on same node by service proxy
+		args = []string{"-A", kubeOutputChainName, "-m", "comment", "--comment", comment, "-d", ip,
+			"-j", podFwChainName + "\n"}
+		ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+
+		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
+		// this rule applies to the traffic getting switched (coming for same node pods)
+		comment = "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
+			" to chain " + podFwChainName + "\""
+		args = []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
+			"-m", "comment", "--comment", comment,
+			"-d", ip,
+			"-j", podFwChainName, "\n"}
+		ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+	}
 }
 
 // setup iptable rules to intercept outbound traffic from pods and run it across the
 // firewall chain corresponding to the pod so that egress network policies are enforced
 func (npc *NetworkPolicyController) interceptPodOutboundTraffic(pod podInfo, podFwChainName string) {
-	for _, chain := range defaultChains {
-		// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
-		// this rule applies to the traffic getting forwarded/routed (traffic from the pod destined
-		// to pod on a different node)
+	for _, ipFamilyHandler := range npc.ipFamilyHandlers {
+		var ip string
+		switch ipFamilyHandler.Family {
+		case api.IPv4Protocol:
+			ip, _ = getPodIPv4Address(pod)
+		case api.IPv6Protocol:
+			ip, _ = getPodIPv6Address(pod)
+		}
+
+		for _, chain := range defaultChains {
+			// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
+			// this rule applies to the traffic getting forwarded/routed (traffic from the pod destined
+			// to pod on a different node)
+			comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
+				" to chain " + podFwChainName + "\""
+			args := []string{"-A", chain, "-m", "comment", "--comment", comment, "-s", ip, "-j", podFwChainName, "\n"}
+			ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
+		}
+
+		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
+		// this rule applies to the traffic getting switched (coming for same node pods)
 		comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
 			" to chain " + podFwChainName + "\""
-		args := []string{"-A", chain, "-m", "comment", "--comment", comment, "-s", pod.ip, "-j", podFwChainName, "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
+		args := []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
+			"-m", "comment", "--comment", comment,
+			"-s", ip,
+			"-j", podFwChainName, "\n"}
+		ipFamilyHandler.filterTableRules.WriteString(strings.Join(args, " "))
 	}
-
-	// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
-	// this rule applies to the traffic getting switched (coming for same node pods)
-	comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
-		" to chain " + podFwChainName + "\""
-	args := []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
-		"-m", "comment", "--comment", comment,
-		"-s", pod.ip,
-		"-j", podFwChainName, "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
 }
 
 func (npc *NetworkPolicyController) getLocalPods(localPods map[string]podInfo, nodeIP string) {
@@ -258,7 +294,7 @@ func (npc *NetworkPolicyController) getLocalPods(localPods map[string]podInfo, n
 		if strings.Compare(pod.Status.HostIP, nodeIP) != 0 || !isNetPolActionable(pod) {
 			continue
 		}
-		localPods[pod.Status.PodIP] = podInfo{ip: pod.Status.PodIP,
+		localPods[pod.Status.PodIP] = podInfo{ips: pod.Status.PodIPs,
 			name:      pod.ObjectMeta.Name,
 			namespace: pod.ObjectMeta.Namespace,
 			labels:    pod.ObjectMeta.Labels}

--- a/pkg/controllers/proxy/network_service_graceful.go
+++ b/pkg/controllers/proxy/network_service_graceful.go
@@ -28,6 +28,7 @@ type gracefulRequest struct {
 func (nsc *NetworkServicesController) ipvsDeleteDestination(svc *ipvs.Service, dst *ipvs.Destination) error {
 	// If we have enabled graceful termination set the weight of the destination to 0
 	// then add it to the queue for graceful termination
+	// ln := nsc.lnHandlers[svc.AddressFamily]
 	if nsc.gracefulTermination {
 		req := gracefulRequest{
 			ipvsSvc:      svc,
@@ -121,6 +122,7 @@ func (nsc *NetworkServicesController) gracefulDeleteIpvsDestination(req graceful
 
 	// Destination has has one or more conditions for deletion
 	if deleteDestination {
+		// ln := nsc.lnHandlers[req.ipvsSvc.AddressFamily]
 		klog.V(2).Infof("Deleting IPVS destination: %s", ipvsDestinationString(req.ipvsDst))
 		if err := nsc.ln.ipvsDelDestination(req.ipvsSvc, req.ipvsDst); err != nil {
 			klog.Errorf("Failed to delete IPVS destination: %s, %s",
@@ -133,6 +135,7 @@ func (nsc *NetworkServicesController) gracefulDeleteIpvsDestination(req graceful
 // getConnStats returns the number of active & inactive connections for the IPVS destination
 func (nsc *NetworkServicesController) getIpvsDestinationConnStats(ipvsSvc *ipvs.Service,
 	dest *ipvs.Destination) (int, int, error) {
+	// ln := nsc.lnHandlers[ipvsSvc.AddressFamily]
 	destStats, err := nsc.ln.ipvsGetDestinations(ipvsSvc)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get IPVS destinations for service : %s : %s",

--- a/pkg/controllers/proxy/network_services_controller_moq.go
+++ b/pkg/controllers/proxy/network_services_controller_moq.go
@@ -24,25 +24,25 @@ var _ LinuxNetworking = &LinuxNetworkingMock{}
 // 			cleanupMangleTableRuleFunc: func(ip string, protocol string, port string, fwmark string, tcpMSS int) error {
 // 				panic("mock out the cleanupMangleTableRule method")
 // 			},
-// 			configureContainerForDSRFunc: func(vip string, endpointIP string, containerID string, pid int, hostNetworkNamespaceHandle netns.NsHandle) error {
+// 			configureContainerForDSRFunc: func(vip, endpointIP string, ipFamily uint16, containerID string, pid int, hostNetworkNamespaceHandle netns.NsHandle) error {
 // 				panic("mock out the configureContainerForDSR method")
 // 			},
 // 			getKubeDummyInterfaceFunc: func() (netlink.Link, error) {
 // 				panic("mock out the getKubeDummyInterface method")
 // 			},
-// 			ipAddrAddFunc: func(iface netlink.Link, ip string, addRoute bool) error {
+// 			ipAddrAddFunc: func(iface netlink.Link, ip net.IP, ipFamily uint16, addRoute bool) error {
 // 				panic("mock out the ipAddrAdd method")
 // 			},
-// 			ipAddrDelFunc: func(iface netlink.Link, ip string) error {
+// 			ipAddrDelFunc: func(iface netlink.Link, ip net.IP, ipFamily uint16) error {
 // 				panic("mock out the ipAddrDel method")
 // 			},
-// 			ipvsAddFWMarkServiceFunc: func(vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+// 			ipvsAddFWMarkServiceFunc: func(vip net.IP, ipFamily, protocol, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 // 				panic("mock out the ipvsAddFWMarkService method")
 // 			},
 // 			ipvsAddServerFunc: func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error {
 // 				panic("mock out the ipvsAddServer method")
 // 			},
-// 			ipvsAddServiceFunc: func(svcs []*ipvs.Service, vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+// 			ipvsAddServiceFunc: func(svcs []*ipvs.Service, vip net.IP, ipFamily, protocol, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 // 				panic("mock out the ipvsAddService method")
 // 			},
 // 			ipvsDelDestinationFunc: func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error {
@@ -57,6 +57,9 @@ var _ LinuxNetworking = &LinuxNetworkingMock{}
 // 			ipvsGetServicesFunc: func() ([]*ipvs.Service, error) {
 // 				panic("mock out the ipvsGetServices method")
 // 			},
+// 			ipvsGetServicesPerFamilyFunc: func() (map[uint16][]*ipvs.Service, error) {
+// 				panic("mock out the ipvsGetServices method")
+// 			},
 // 			ipvsNewDestinationFunc: func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error {
 // 				panic("mock out the ipvsNewDestination method")
 // 			},
@@ -69,10 +72,10 @@ var _ LinuxNetworking = &LinuxNetworkingMock{}
 // 			ipvsUpdateServiceFunc: func(ipvsSvc *ipvs.Service) error {
 // 				panic("mock out the ipvsUpdateService method")
 // 			},
-// 			prepareEndpointForDsrWithCRIFunc: func(runtimeEndpoint string, containerID string, endpointIP string, vip string) error {
+// 			prepareEndpointForDsrWithCRIFunc: func(runtimeEndpoint, containerID, endpointIP string, vip string, ipFamily uint16) error {
 // 				panic("mock out the prepareEndpointForDsrWithCRI method")
 // 			},
-// 			prepareEndpointForDsrWithDockerFunc: func(containerID string, endpointIP string, vip string) error {
+// 			prepareEndpointForDsrWithDockerFunc: func(containerID, endpointIP, vip stringm, ipFamily uint16) error {
 // 				panic("mock out the prepareEndpointForDsrWithDocker method")
 // 			},
 // 			setupPolicyRoutingForDSRFunc: func() error {
@@ -92,25 +95,25 @@ type LinuxNetworkingMock struct {
 	cleanupMangleTableRuleFunc func(ip string, protocol string, port string, fwmark string, tcpMSS int) error
 
 	// configureContainerForDSRFunc mocks the configureContainerForDSR method.
-	configureContainerForDSRFunc func(vip string, endpointIP string, containerID string, pid int, hostNetworkNamespaceHandle netns.NsHandle) error
+	configureContainerForDSRFunc func(vip, endpointIP string, ipFamily uint16, containerID string, pid int, hostNetworkNamespaceHandle netns.NsHandle) error
 
 	// getKubeDummyInterfaceFunc mocks the getKubeDummyInterface method.
 	getKubeDummyInterfaceFunc func() (netlink.Link, error)
 
 	// ipAddrAddFunc mocks the ipAddrAdd method.
-	ipAddrAddFunc func(iface netlink.Link, ip string, addRoute bool) error
+	ipAddrAddFunc func(iface netlink.Link, ip net.IP, ipFamily uint16, addRoute bool) error
 
 	// ipAddrDelFunc mocks the ipAddrDel method.
-	ipAddrDelFunc func(iface netlink.Link, ip string) error
+	ipAddrDelFunc func(iface netlink.Link, ip net.IP, ipFamily uint16) error
 
 	// ipvsAddFWMarkServiceFunc mocks the ipvsAddFWMarkService method.
-	ipvsAddFWMarkServiceFunc func(vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
+	ipvsAddFWMarkServiceFunc func(vip net.IP, ipFamily, protocol, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
 
 	// ipvsAddServerFunc mocks the ipvsAddServer method.
 	ipvsAddServerFunc func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error
 
 	// ipvsAddServiceFunc mocks the ipvsAddService method.
-	ipvsAddServiceFunc func(svcs []*ipvs.Service, vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
+	ipvsAddServiceFunc func(svcs []*ipvs.Service, vip net.IP, ipFamily, protocol, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
 
 	// ipvsDelDestinationFunc mocks the ipvsDelDestination method.
 	ipvsDelDestinationFunc func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error
@@ -123,6 +126,9 @@ type LinuxNetworkingMock struct {
 
 	// ipvsGetServicesFunc mocks the ipvsGetServices method.
 	ipvsGetServicesFunc func() ([]*ipvs.Service, error)
+
+	// ipvsGetServicesPerFamilyFunc mocks the ipvsGetServicesPerFamily method.
+	ipvsGetServicesPerFamilyFunc func() (map[uint16][]*ipvs.Service, error)
 
 	// ipvsNewDestinationFunc mocks the ipvsNewDestination method.
 	ipvsNewDestinationFunc func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error
@@ -137,10 +143,10 @@ type LinuxNetworkingMock struct {
 	ipvsUpdateServiceFunc func(ipvsSvc *ipvs.Service) error
 
 	// prepareEndpointForDsrWithCRIFunc mocks the prepareEndpointForDsrWithCRI method.
-	prepareEndpointForDsrWithCRIFunc func(runtimeEndpoint string, containerID string, endpointIP string, vip string) error
+	prepareEndpointForDsrWithCRIFunc func(runtimeEndpoint, containerID, endpointIP, vip string, ipFamily uint16) error
 
 	// prepareEndpointForDsrWithDockerFunc mocks the prepareEndpointForDsrWithDocker method.
-	prepareEndpointForDsrWithDockerFunc func(containerID string, endpointIP string, vip string) error
+	prepareEndpointForDsrWithDockerFunc func(containerID, endpointIP, vip string, ipFamily uint16) error
 
 	// setupPolicyRoutingForDSRFunc mocks the setupPolicyRoutingForDSR method.
 	setupPolicyRoutingForDSRFunc func() error
@@ -169,6 +175,8 @@ type LinuxNetworkingMock struct {
 			Vip string
 			// EndpointIP is the endpointIP argument value.
 			EndpointIP string
+			// IPFamily is the ipFamily argument value,
+			IPFamily uint16
 			// ContainerID is the containerID argument value.
 			ContainerID string
 			// Pid is the pid argument value.
@@ -184,7 +192,9 @@ type LinuxNetworkingMock struct {
 			// Iface is the iface argument value.
 			Iface netlink.Link
 			// IP is the ip argument value.
-			IP string
+			IP net.IP
+			// IPFamily is the ip family argument value.
+			IPFamily uint16
 			// AddRoute is the addRoute argument value.
 			AddRoute bool
 		}
@@ -193,12 +203,16 @@ type LinuxNetworkingMock struct {
 			// Iface is the iface argument value.
 			Iface netlink.Link
 			// IP is the ip argument value.
-			IP string
+			IP net.IP
+			// IPFamily is the ip family argument value.
+			IPFamily uint16
 		}
 		// ipvsAddFWMarkService holds details about calls to the ipvsAddFWMarkService method.
 		ipvsAddFWMarkService []struct {
 			// Vip is the vip argument value.
 			Vip net.IP
+			// IPFamily is the ip family argument value.
+			IPFamily uint16
 			// Protocol is the protocol argument value.
 			Protocol uint16
 			// Port is the port argument value.
@@ -225,6 +239,8 @@ type LinuxNetworkingMock struct {
 			Svcs []*ipvs.Service
 			// Vip is the vip argument value.
 			Vip net.IP
+			// IPFamily is the ip family value.
+			IPFamily uint16
 			// Protocol is the protocol argument value.
 			Protocol uint16
 			// Port is the port argument value.
@@ -257,6 +273,9 @@ type LinuxNetworkingMock struct {
 		}
 		// ipvsGetServices holds details about calls to the ipvsGetServices method.
 		ipvsGetServices []struct {
+		}
+		// ipvsGetServicesPerFamily holds details about calls to the ipvsGetServicesPerFamily method.
+		ipvsGetServicesPerFamily []struct {
 		}
 		// ipvsNewDestination holds details about calls to the ipvsNewDestination method.
 		ipvsNewDestination []struct {
@@ -292,6 +311,8 @@ type LinuxNetworkingMock struct {
 			EndpointIP string
 			// Vip is the vip argument value.
 			Vip string
+			// IPFamily is the ipFamily argument value.
+			IPFamily uint16
 		}
 		// prepareEndpointForDsrWithDocker holds details about calls to the prepareEndpointForDsrWithDocker method.
 		prepareEndpointForDsrWithDocker []struct {
@@ -301,6 +322,8 @@ type LinuxNetworkingMock struct {
 			EndpointIP string
 			// Vip is the vip argument value.
 			Vip string
+			// IPFamily is the ipFamily argument value.
+			IPFamily uint16
 		}
 		// setupPolicyRoutingForDSR holds details about calls to the setupPolicyRoutingForDSR method.
 		setupPolicyRoutingForDSR []struct {
@@ -323,6 +346,7 @@ type LinuxNetworkingMock struct {
 	lockipvsDelService                  sync.RWMutex
 	lockipvsGetDestinations             sync.RWMutex
 	lockipvsGetServices                 sync.RWMutex
+	lockipvsGetServicesPerFamily        sync.RWMutex
 	lockipvsNewDestination              sync.RWMutex
 	lockipvsNewService                  sync.RWMutex
 	lockipvsUpdateDestination           sync.RWMutex
@@ -381,19 +405,21 @@ func (mock *LinuxNetworkingMock) cleanupMangleTableRuleCalls() []struct {
 }
 
 // configureContainerForDSR calls configureContainerForDSRFunc.
-func (mock *LinuxNetworkingMock) configureContainerForDSR(vip string, endpointIP string, containerID string, pid int, hostNetworkNamespaceHandle netns.NsHandle) error {
+func (mock *LinuxNetworkingMock) configureContainerForDSR(vip string, endpointIP string, ipFamily uint16, containerID string, pid int, hostNetworkNamespaceHandle netns.NsHandle) error {
 	if mock.configureContainerForDSRFunc == nil {
 		panic("LinuxNetworkingMock.configureContainerForDSRFunc: method is nil but LinuxNetworking.configureContainerForDSR was just called")
 	}
 	callInfo := struct {
 		Vip                        string
 		EndpointIP                 string
+		IPFamily                   uint16
 		ContainerID                string
 		Pid                        int
 		HostNetworkNamespaceHandle netns.NsHandle
 	}{
 		Vip:                        vip,
 		EndpointIP:                 endpointIP,
+		IPFamily:                   ipFamily,
 		ContainerID:                containerID,
 		Pid:                        pid,
 		HostNetworkNamespaceHandle: hostNetworkNamespaceHandle,
@@ -401,7 +427,7 @@ func (mock *LinuxNetworkingMock) configureContainerForDSR(vip string, endpointIP
 	mock.lockconfigureContainerForDSR.Lock()
 	mock.calls.configureContainerForDSR = append(mock.calls.configureContainerForDSR, callInfo)
 	mock.lockconfigureContainerForDSR.Unlock()
-	return mock.configureContainerForDSRFunc(vip, endpointIP, containerID, pid, hostNetworkNamespaceHandle)
+	return mock.configureContainerForDSRFunc(vip, endpointIP, ipFamily, containerID, pid, hostNetworkNamespaceHandle)
 }
 
 // configureContainerForDSRCalls gets all the calls that were made to configureContainerForDSR.
@@ -410,6 +436,7 @@ func (mock *LinuxNetworkingMock) configureContainerForDSR(vip string, endpointIP
 func (mock *LinuxNetworkingMock) configureContainerForDSRCalls() []struct {
 	Vip                        string
 	EndpointIP                 string
+	IPFamily                   uint16
 	ContainerID                string
 	Pid                        int
 	HostNetworkNamespaceHandle netns.NsHandle
@@ -417,6 +444,7 @@ func (mock *LinuxNetworkingMock) configureContainerForDSRCalls() []struct {
 	var calls []struct {
 		Vip                        string
 		EndpointIP                 string
+		IPFamily                   uint16
 		ContainerID                string
 		Pid                        int
 		HostNetworkNamespaceHandle netns.NsHandle
@@ -454,23 +482,25 @@ func (mock *LinuxNetworkingMock) getKubeDummyInterfaceCalls() []struct {
 }
 
 // ipAddrAdd calls ipAddrAddFunc.
-func (mock *LinuxNetworkingMock) ipAddrAdd(iface netlink.Link, ip string, addRoute bool) error {
+func (mock *LinuxNetworkingMock) ipAddrAdd(iface netlink.Link, ip net.IP, ipFamily uint16, addRoute bool) error {
 	if mock.ipAddrAddFunc == nil {
 		panic("LinuxNetworkingMock.ipAddrAddFunc: method is nil but LinuxNetworking.ipAddrAdd was just called")
 	}
 	callInfo := struct {
 		Iface    netlink.Link
-		IP       string
+		IP       net.IP
+		IPFamily uint16
 		AddRoute bool
 	}{
 		Iface:    iface,
 		IP:       ip,
+		IPFamily: ipFamily,
 		AddRoute: addRoute,
 	}
 	mock.lockipAddrAdd.Lock()
 	mock.calls.ipAddrAdd = append(mock.calls.ipAddrAdd, callInfo)
 	mock.lockipAddrAdd.Unlock()
-	return mock.ipAddrAddFunc(iface, ip, addRoute)
+	return mock.ipAddrAddFunc(iface, ip, ipFamily, addRoute)
 }
 
 // ipAddrAddCalls gets all the calls that were made to ipAddrAdd.
@@ -478,12 +508,14 @@ func (mock *LinuxNetworkingMock) ipAddrAdd(iface netlink.Link, ip string, addRou
 //     len(mockedLinuxNetworking.ipAddrAddCalls())
 func (mock *LinuxNetworkingMock) ipAddrAddCalls() []struct {
 	Iface    netlink.Link
-	IP       string
+	IP       net.IP
+	IPFamily uint16
 	AddRoute bool
 } {
 	var calls []struct {
 		Iface    netlink.Link
-		IP       string
+		IP       net.IP
+		IPFamily uint16
 		AddRoute bool
 	}
 	mock.lockipAddrAdd.RLock()
@@ -493,33 +525,37 @@ func (mock *LinuxNetworkingMock) ipAddrAddCalls() []struct {
 }
 
 // ipAddrDel calls ipAddrDelFunc.
-func (mock *LinuxNetworkingMock) ipAddrDel(iface netlink.Link, ip string) error {
+func (mock *LinuxNetworkingMock) ipAddrDel(iface netlink.Link, ip net.IP, ipFamily uint16) error {
 	if mock.ipAddrDelFunc == nil {
 		panic("LinuxNetworkingMock.ipAddrDelFunc: method is nil but LinuxNetworking.ipAddrDel was just called")
 	}
 	callInfo := struct {
-		Iface netlink.Link
-		IP    string
+		Iface    netlink.Link
+		IP       net.IP
+		IPFamily uint16
 	}{
-		Iface: iface,
-		IP:    ip,
+		Iface:    iface,
+		IP:       ip,
+		IPFamily: ipFamily,
 	}
 	mock.lockipAddrDel.Lock()
 	mock.calls.ipAddrDel = append(mock.calls.ipAddrDel, callInfo)
 	mock.lockipAddrDel.Unlock()
-	return mock.ipAddrDelFunc(iface, ip)
+	return mock.ipAddrDelFunc(iface, ip, ipFamily)
 }
 
 // ipAddrDelCalls gets all the calls that were made to ipAddrDel.
 // Check the length with:
 //     len(mockedLinuxNetworking.ipAddrDelCalls())
 func (mock *LinuxNetworkingMock) ipAddrDelCalls() []struct {
-	Iface netlink.Link
-	IP    string
+	Iface    netlink.Link
+	IP       net.IP
+	IPFamily uint16
 } {
 	var calls []struct {
-		Iface netlink.Link
-		IP    string
+		Iface    netlink.Link
+		IP       net.IP
+		IPFamily uint16
 	}
 	mock.lockipAddrDel.RLock()
 	calls = mock.calls.ipAddrDel
@@ -528,12 +564,13 @@ func (mock *LinuxNetworkingMock) ipAddrDelCalls() []struct {
 }
 
 // ipvsAddFWMarkService calls ipvsAddFWMarkServiceFunc.
-func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, ipFamily, protocol, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 	if mock.ipvsAddFWMarkServiceFunc == nil {
 		panic("LinuxNetworkingMock.ipvsAddFWMarkServiceFunc: method is nil but LinuxNetworking.ipvsAddFWMarkService was just called")
 	}
 	callInfo := struct {
 		Vip               net.IP
+		IPFamily          uint16
 		Protocol          uint16
 		Port              uint16
 		Persistent        bool
@@ -542,6 +579,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, protocol uint1
 		Flags             schedFlags
 	}{
 		Vip:               vip,
+		IPFamily:          ipFamily,
 		Protocol:          protocol,
 		Port:              port,
 		Persistent:        persistent,
@@ -552,7 +590,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, protocol uint1
 	mock.lockipvsAddFWMarkService.Lock()
 	mock.calls.ipvsAddFWMarkService = append(mock.calls.ipvsAddFWMarkService, callInfo)
 	mock.lockipvsAddFWMarkService.Unlock()
-	return mock.ipvsAddFWMarkServiceFunc(vip, protocol, port, persistent, persistentTimeout, scheduler, flags)
+	return mock.ipvsAddFWMarkServiceFunc(vip, ipFamily, protocol, port, persistent, persistentTimeout, scheduler, flags)
 }
 
 // ipvsAddFWMarkServiceCalls gets all the calls that were made to ipvsAddFWMarkService.
@@ -560,6 +598,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, protocol uint1
 //     len(mockedLinuxNetworking.ipvsAddFWMarkServiceCalls())
 func (mock *LinuxNetworkingMock) ipvsAddFWMarkServiceCalls() []struct {
 	Vip               net.IP
+	IPFamily          uint16
 	Protocol          uint16
 	Port              uint16
 	Persistent        bool
@@ -569,6 +608,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkServiceCalls() []struct {
 } {
 	var calls []struct {
 		Vip               net.IP
+		IPFamily          uint16
 		Protocol          uint16
 		Port              uint16
 		Persistent        bool
@@ -618,13 +658,14 @@ func (mock *LinuxNetworkingMock) ipvsAddServerCalls() []struct {
 }
 
 // ipvsAddService calls ipvsAddServiceFunc.
-func (mock *LinuxNetworkingMock) ipvsAddService(svcs []*ipvs.Service, vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+func (mock *LinuxNetworkingMock) ipvsAddService(svcs []*ipvs.Service, vip net.IP, ipFamily, protocol, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 	if mock.ipvsAddServiceFunc == nil {
 		panic("LinuxNetworkingMock.ipvsAddServiceFunc: method is nil but LinuxNetworking.ipvsAddService was just called")
 	}
 	callInfo := struct {
 		Svcs              []*ipvs.Service
 		Vip               net.IP
+		IPFamily          uint16
 		Protocol          uint16
 		Port              uint16
 		Persistent        bool
@@ -634,6 +675,7 @@ func (mock *LinuxNetworkingMock) ipvsAddService(svcs []*ipvs.Service, vip net.IP
 	}{
 		Svcs:              svcs,
 		Vip:               vip,
+		IPFamily:          ipFamily,
 		Protocol:          protocol,
 		Port:              port,
 		Persistent:        persistent,
@@ -644,7 +686,7 @@ func (mock *LinuxNetworkingMock) ipvsAddService(svcs []*ipvs.Service, vip net.IP
 	mock.lockipvsAddService.Lock()
 	mock.calls.ipvsAddService = append(mock.calls.ipvsAddService, callInfo)
 	mock.lockipvsAddService.Unlock()
-	return mock.ipvsAddServiceFunc(svcs, vip, protocol, port, persistent, persistentTimeout, scheduler, flags)
+	return mock.ipvsAddServiceFunc(svcs, vip, ipFamily, protocol, port, persistent, persistentTimeout, scheduler, flags)
 }
 
 // ipvsAddServiceCalls gets all the calls that were made to ipvsAddService.
@@ -653,6 +695,7 @@ func (mock *LinuxNetworkingMock) ipvsAddService(svcs []*ipvs.Service, vip net.IP
 func (mock *LinuxNetworkingMock) ipvsAddServiceCalls() []struct {
 	Svcs              []*ipvs.Service
 	Vip               net.IP
+	IPFamily          uint16
 	Protocol          uint16
 	Port              uint16
 	Persistent        bool
@@ -663,6 +706,7 @@ func (mock *LinuxNetworkingMock) ipvsAddServiceCalls() []struct {
 	var calls []struct {
 		Svcs              []*ipvs.Service
 		Vip               net.IP
+		IPFamily          uint16
 		Protocol          uint16
 		Port              uint16
 		Persistent        bool
@@ -799,6 +843,19 @@ func (mock *LinuxNetworkingMock) ipvsGetServicesCalls() []struct {
 	return calls
 }
 
+// ipvsGetServicesPerFamily calls ipvsGetServicesPerFamilyFunc.
+func (mock *LinuxNetworkingMock) ipvsGetServicesPerFamily() (map[uint16][]*ipvs.Service, error) {
+	if mock.ipvsGetServicesFunc == nil {
+		panic("LinuxNetworkingMock.ipvsGetServicesPerFamilyFunc: method is nil but LinuxNetworking.ipvsGetServicesPerFamily was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockipvsGetServicesPerFamily.Lock()
+	mock.calls.ipvsGetServicesPerFamily = append(mock.calls.ipvsGetServicesPerFamily, callInfo)
+	mock.lockipvsGetServicesPerFamily.Unlock()
+	return mock.ipvsGetServicesPerFamilyFunc()
+}
+
 // ipvsNewDestination calls ipvsNewDestinationFunc.
 func (mock *LinuxNetworkingMock) ipvsNewDestination(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error {
 	if mock.ipvsNewDestinationFunc == nil {
@@ -932,7 +989,7 @@ func (mock *LinuxNetworkingMock) ipvsUpdateServiceCalls() []struct {
 }
 
 // prepareEndpointForDsrWithCRI calls prepareEndpointForDsrWithCRIFunc.
-func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithCRI(runtimeEndpoint string, containerID string, endpointIP string, vip string) error {
+func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithCRI(runtimeEndpoint, containerID, endpointIP, vip string, ipFamily uint16) error {
 	if mock.prepareEndpointForDsrWithCRIFunc == nil {
 		panic("LinuxNetworkingMock.prepareEndpointForDsrWithCRIFunc: method is nil but LinuxNetworking.prepareEndpointForDsrWithCRI was just called")
 	}
@@ -941,16 +998,18 @@ func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithCRI(runtimeEndpoint st
 		ContainerID     string
 		EndpointIP      string
 		Vip             string
+		IPFamily        uint16
 	}{
 		RuntimeEndpoint: runtimeEndpoint,
 		ContainerID:     containerID,
 		EndpointIP:      endpointIP,
 		Vip:             vip,
+		IPFamily:        ipFamily,
 	}
 	mock.lockprepareEndpointForDsrWithCRI.Lock()
 	mock.calls.prepareEndpointForDsrWithCRI = append(mock.calls.prepareEndpointForDsrWithCRI, callInfo)
 	mock.lockprepareEndpointForDsrWithCRI.Unlock()
-	return mock.prepareEndpointForDsrWithCRIFunc(runtimeEndpoint, containerID, endpointIP, vip)
+	return mock.prepareEndpointForDsrWithCRIFunc(runtimeEndpoint, containerID, endpointIP, vip, ipFamily)
 }
 
 // prepareEndpointForDsrWithCRICalls gets all the calls that were made to prepareEndpointForDsrWithCRI.
@@ -961,12 +1020,14 @@ func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithCRICalls() []struct {
 	ContainerID     string
 	EndpointIP      string
 	Vip             string
+	IPFamily        uint16
 } {
 	var calls []struct {
 		RuntimeEndpoint string
 		ContainerID     string
 		EndpointIP      string
 		Vip             string
+		IPFamily        uint16
 	}
 	mock.lockprepareEndpointForDsrWithCRI.RLock()
 	calls = mock.calls.prepareEndpointForDsrWithCRI
@@ -975,7 +1036,7 @@ func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithCRICalls() []struct {
 }
 
 // prepareEndpointForDsrWithDocker calls prepareEndpointForDsrWithDockerFunc.
-func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithDocker(containerID string, endpointIP string, vip string) error {
+func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithDocker(containerID, endpointIP, vip string, ipFamily uint16) error {
 	if mock.prepareEndpointForDsrWithDockerFunc == nil {
 		panic("LinuxNetworkingMock.prepareEndpointForDsrWithDockerFunc: method is nil but LinuxNetworking.prepareEndpointForDsrWithDocker was just called")
 	}
@@ -983,15 +1044,17 @@ func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithDocker(containerID str
 		ContainerID string
 		EndpointIP  string
 		Vip         string
+		IPFamily    uint16
 	}{
 		ContainerID: containerID,
 		EndpointIP:  endpointIP,
 		Vip:         vip,
+		IPFamily:    ipFamily,
 	}
 	mock.lockprepareEndpointForDsrWithDocker.Lock()
 	mock.calls.prepareEndpointForDsrWithDocker = append(mock.calls.prepareEndpointForDsrWithDocker, callInfo)
 	mock.lockprepareEndpointForDsrWithDocker.Unlock()
-	return mock.prepareEndpointForDsrWithDockerFunc(containerID, endpointIP, vip)
+	return mock.prepareEndpointForDsrWithDockerFunc(containerID, endpointIP, vip, ipFamily)
 }
 
 // prepareEndpointForDsrWithDockerCalls gets all the calls that were made to prepareEndpointForDsrWithDocker.
@@ -1001,11 +1064,13 @@ func (mock *LinuxNetworkingMock) prepareEndpointForDsrWithDockerCalls() []struct
 	ContainerID string
 	EndpointIP  string
 	Vip         string
+	IPFamily    uint16
 } {
 	var calls []struct {
 		ContainerID string
 		EndpointIP  string
 		Vip         string
+		IPFamily    uint16
 	}
 	mock.lockprepareEndpointForDsrWithDocker.RLock()
 	calls = mock.calls.prepareEndpointForDsrWithDocker

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -33,7 +33,8 @@ func attemptNamespaceResetAfterError(hostNSHandle netns.NsHandle) {
 }
 
 func (ln *linuxNetworking) configureContainerForDSR(
-	vip, endpointIP, containerID string, pid int, hostNetworkNamespaceHandle netns.NsHandle) error {
+	vip, endpointIP string, ipFamily uint16, containerID string, pid int,
+	hostNetworkNamespaceHandle netns.NsHandle) error {
 	endpointNamespaceHandle, err := netns.GetFromPid(pid)
 	if err != nil {
 		return fmt.Errorf("failed to get endpoint namespace (containerID=%s, pid=%d, error=%v)",
@@ -114,7 +115,7 @@ func (ln *linuxNetworking) configureContainerForDSR(
 	}
 
 	// assign VIP to the KUBE_TUNNEL_IF interface
-	err = ln.ipAddrAdd(tunIf, vip, false)
+	err = ln.ipAddrAdd(tunIf, net.ParseIP(vip), ipFamily, false)
 	if err != nil && err.Error() != IfaceHasAddr {
 		attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
 		return fmt.Errorf("failed to assign vip %s to kube-tunnel-if interface", vip)

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -45,7 +45,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
 				nodeAsnNumber:     100,
-				podCidr:           "172.20.0.0/24",
+				// podCidrv4:         "172.20.0.0/24",
 			},
 			[]*v1core.Node{
 				{
@@ -182,7 +182,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpEnableInternal: true,
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				podCidr:           "172.20.0.0/24",
+				// podCidrv4:         "172.20.0.0/24",
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
 						Conf: &gobgpapi.PeerConf{
@@ -353,7 +353,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpEnableInternal: false,
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				podCidr:           "172.20.0.0/24",
+				// podCidrv4:         "172.20.0.0/24",
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
 						Conf: &gobgpapi.PeerConf{
@@ -507,7 +507,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpFullMeshMode:   false,
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				podCidr:           "172.20.0.0/24",
+				// podCidrv4:         "172.20.0.0/24",
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
 						Conf: &gobgpapi.PeerConf{
@@ -684,7 +684,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpFullMeshMode:   false,
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				podCidr:           "172.20.0.0/24",
+				// podCidrv4:         "172.20.0.0/24",
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
 						Conf: &gobgpapi.PeerConf{
@@ -861,7 +861,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpServer:         gobgp.NewBgpServer(),
 				advertisePodCidr:  true,
 				activeNodes:       make(map[string]bool),
-				podCidr:           "172.20.0.0/24",
+				// podCidrv4:         "172.20.0.0/24",
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
 						Conf: &gobgpapi.PeerConf{

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -3,7 +3,6 @@ package routing
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"reflect"
 	"testing"
@@ -34,7 +33,7 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for service with ClusterIP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -55,7 +54,7 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for service with ClusterIP/NodePort/LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -96,7 +95,7 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for invalid service type",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -126,7 +125,7 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for headless service",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -255,7 +254,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for service with external IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -278,7 +277,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for services with external IPs of type ClusterIP/NodePort/LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -323,7 +322,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for invalid service type",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -355,7 +354,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for headless service",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -397,7 +396,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"skip bgp path to loadbalancerIP for service without LoadBalancer IP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -425,7 +424,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path to loadbalancerIP for service with LoadBalancer IP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -459,7 +458,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"no bgp path to nil loadbalancerIPs for service with LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -483,7 +482,7 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"no bgp path to loadbalancerIPs for service with LoadBalancer and skiplbips annotation",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// nodeIPv4:  net.ParseIP("10.0.0.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -608,7 +607,7 @@ func Test_advertiseAnnotationOptOut(t *testing.T) {
 			"add bgp paths for all service IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.1.1"),
+				// nodeIPv4:  net.ParseIP("10.0.1.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -670,7 +669,7 @@ func Test_advertiseAnnotationOptOut(t *testing.T) {
 			"opt out to advertise any IPs via annotations",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.1.1"),
+				// nodeIPv4:  net.ParseIP("10.0.1.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -799,7 +798,7 @@ func Test_advertiseAnnotationOptIn(t *testing.T) {
 			"no bgp paths for any service IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.1.1"),
+				// nodeIPv4:  net.ParseIP("10.0.1.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -853,7 +852,7 @@ func Test_advertiseAnnotationOptIn(t *testing.T) {
 			"opt in to advertise all IPs via annotations",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				nodeIP:    net.ParseIP("10.0.1.1"),
+				// nodeIPv4:  net.ParseIP("10.0.1.1"),
 			},
 			[]*v1core.Service{
 				{
@@ -1148,8 +1147,8 @@ func Test_advertisePodRoute(t *testing.T) {
 			"add bgp path for pod cidr using NODE_NAME",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				podCidr:   "172.20.0.0/24",
-				nodeIP:    net.ParseIP("10.0.0.1"),
+				// podCidrv4: "172.20.0.0/24",
+				// nodeIPv4: net.ParseIP("10.0.0.1"),
 			},
 			"node-1",
 			&v1core.Node{
@@ -1170,8 +1169,8 @@ func Test_advertisePodRoute(t *testing.T) {
 			&NetworkRoutingController{
 				bgpServer:        gobgp.NewBgpServer(),
 				hostnameOverride: "node-1",
-				podCidr:          "172.20.0.0/24",
-				nodeIP:           net.ParseIP("10.0.0.1"),
+				// podCidrv4:        "172.20.0.0/24",
+				// nodeIPv4:         net.ParseIP("10.0.0.1"),
 			},
 			"",
 			&v1core.Node{
@@ -1318,9 +1317,9 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				nodeIP:          net.ParseIP("10.0.0.0"),
-				bgpServer:       gobgp.NewBgpServer(),
-				activeNodes:     make(map[string]bool),
+				// nodeIPv4:        net.ParseIP("10.0.0.0"),
+				bgpServer:   gobgp.NewBgpServer(),
+				activeNodes: make(map[string]bool),
 			},
 			[]*v1core.Node{
 				{
@@ -1346,9 +1345,9 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				nodeIP:          net.ParseIP("10.0.0.0"),
-				bgpServer:       gobgp.NewBgpServer(),
-				activeNodes:     make(map[string]bool),
+				// nodeIPv4:        net.ParseIP("10.0.0.0"),
+				bgpServer:   gobgp.NewBgpServer(),
+				activeNodes: make(map[string]bool),
 			},
 			[]*v1core.Node{
 				{
@@ -1388,8 +1387,8 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				nodeIP:          net.ParseIP("10.0.0.0"),
-				bgpServer:       gobgp.NewBgpServer(),
+				// nodeIPv4:        net.ParseIP("10.0.0.0"),
+				bgpServer: gobgp.NewBgpServer(),
 				activeNodes: map[string]bool{
 					"10.0.0.2": true,
 				},
@@ -1418,10 +1417,10 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: false,
 				clientset:       fake.NewSimpleClientset(),
-				nodeIP:          net.ParseIP("10.0.0.0"),
-				bgpServer:       gobgp.NewBgpServer(),
-				activeNodes:     make(map[string]bool),
-				nodeAsnNumber:   100,
+				// nodeIPv4:        net.ParseIP("10.0.0.0"),
+				bgpServer:     gobgp.NewBgpServer(),
+				activeNodes:   make(map[string]bool),
+				nodeAsnNumber: 100,
 			},
 			[]*v1core.Node{
 				{
@@ -1524,10 +1523,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 		{
 			"RR server with int cluster id",
 			&NetworkRoutingController{
-				bgpFullMeshMode:  false,
-				bgpPort:          10000,
-				clientset:        fake.NewSimpleClientset(),
-				nodeIP:           net.ParseIP("10.0.0.0"),
+				bgpFullMeshMode: false,
+				bgpPort:         10000,
+				clientset:       fake.NewSimpleClientset(),
+				// nodeIPv4:         net.ParseIP("10.0.0.0"),
 				routerID:         "10.0.0.0",
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
@@ -1551,10 +1550,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 		{
 			"RR server with IPv4 cluster id",
 			&NetworkRoutingController{
-				bgpFullMeshMode:  false,
-				bgpPort:          10000,
-				clientset:        fake.NewSimpleClientset(),
-				nodeIP:           net.ParseIP("10.0.0.0"),
+				bgpFullMeshMode: false,
+				bgpPort:         10000,
+				clientset:       fake.NewSimpleClientset(),
+				// nodeIPv4:         net.ParseIP("10.0.0.0"),
 				routerID:         "10.0.0.0",
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
@@ -1578,10 +1577,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 		{
 			"RR client with int cluster id",
 			&NetworkRoutingController{
-				bgpFullMeshMode:  false,
-				bgpPort:          10000,
-				clientset:        fake.NewSimpleClientset(),
-				nodeIP:           net.ParseIP("10.0.0.0"),
+				bgpFullMeshMode: false,
+				bgpPort:         10000,
+				clientset:       fake.NewSimpleClientset(),
+				// nodeIPv4:         net.ParseIP("10.0.0.0"),
 				routerID:         "10.0.0.0",
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
@@ -1605,10 +1604,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 		{
 			"RR client with IPv4 cluster id",
 			&NetworkRoutingController{
-				bgpFullMeshMode:  false,
-				bgpPort:          10000,
-				clientset:        fake.NewSimpleClientset(),
-				nodeIP:           net.ParseIP("10.0.0.0"),
+				bgpFullMeshMode: false,
+				bgpPort:         10000,
+				clientset:       fake.NewSimpleClientset(),
+				// nodeIPv4:         net.ParseIP("10.0.0.0"),
 				routerID:         "10.0.0.0",
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
@@ -1632,10 +1631,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 		{
 			"RR server with unparseable cluster id",
 			&NetworkRoutingController{
-				bgpFullMeshMode:  false,
-				bgpPort:          10000,
-				clientset:        fake.NewSimpleClientset(),
-				nodeIP:           net.ParseIP("10.0.0.0"),
+				bgpFullMeshMode: false,
+				bgpPort:         10000,
+				clientset:       fake.NewSimpleClientset(),
+				// nodeIPv4:         net.ParseIP("10.0.0.0"),
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
 				nodeAsnNumber:    100,
@@ -1658,10 +1657,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 		{
 			"RR client with unparseable cluster id",
 			&NetworkRoutingController{
-				bgpFullMeshMode:  false,
-				bgpPort:          10000,
-				clientset:        fake.NewSimpleClientset(),
-				nodeIP:           net.ParseIP("10.0.0.0"),
+				bgpFullMeshMode: false,
+				bgpPort:         10000,
+				clientset:       fake.NewSimpleClientset(),
+				// nodeIPv4:         net.ParseIP("10.0.0.0"),
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
 				nodeAsnNumber:    100,

--- a/pkg/controllers/routing/pod_egress.go
+++ b/pkg/controllers/routing/pod_egress.go
@@ -4,116 +4,184 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/coreos/go-iptables/iptables"
 	"k8s.io/klog/v2"
 )
 
 // set up MASQUERADE rule so that egress traffic from the pods gets masqueraded to node's IP
 
 var (
-	podEgressArgs4 = []string{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
-		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
-		"-m", "set", "!", "--match-set", nodeAddrsIPSetName, "dst",
+	podEgressArgs4 = []string{"-m", "set", "--match-set", podSubnetsIPSetNameIPv4, "src",
+		"-m", "set", "!", "--match-set", podSubnetsIPSetNameIPv4, "dst",
+		"-m", "set", "!", "--match-set", nodeAddrsIPSetNameIPv4, "dst",
 		"-j", "MASQUERADE"}
-	podEgressArgs6 = []string{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
-		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
-		"-m", "set", "!", "--match-set", "inet6:" + nodeAddrsIPSetName, "dst",
+	podEgressArgs6 = []string{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetNameIPv6, "src",
+		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetNameIPv6, "dst",
+		"-m", "set", "!", "--match-set", "inet6:" + nodeAddrsIPSetNameIPv6, "dst",
 		"-j", "MASQUERADE"}
-	podEgressArgsBad4 = [][]string{{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
-		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
+	podEgressArgsBad4 = [][]string{{"-m", "set", "--match-set", podSubnetsIPSetNameIPv4, "src",
+		"-m", "set", "!", "--match-set", podSubnetsIPSetNameIPv4, "dst",
 		"-j", "MASQUERADE"}}
-	podEgressArgsBad6 = [][]string{{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
-		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
+	podEgressArgsBad6 = [][]string{{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetNameIPv6, "src",
+		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetNameIPv6, "dst",
 		"-j", "MASQUERADE"}}
 )
 
 func (nrc *NetworkRoutingController) createPodEgressRule() error {
-	iptablesCmdHandler, err := nrc.newIptablesCmdHandler()
-	if err != nil {
-		return errors.New("Failed create iptables handler:" + err.Error())
+	if nrc.enableIPv4 {
+		iptablesCmdHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return fmt.Errorf("failed create iptables handler: %w", err)
+		}
+
+		podEgressArgs := make([]string, len(podEgressArgs4))
+		copy(podEgressArgs, podEgressArgs4)
+		if iptablesCmdHandler.HasRandomFully() {
+			podEgressArgs = append(podEgressArgs, "--random-fully")
+		}
+
+		err = iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", podEgressArgs...)
+		if err != nil {
+			return errors.New("Failed to add iptables rule to masquerade outbound traffic from pods: " +
+				err.Error() + "External connectivity will not work.")
+
+		}
+	}
+	if nrc.enableIPv6 {
+		iptablesCmdHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return fmt.Errorf("failed create iptables handler: %w", err)
+		}
+
+		podEgressArgs := make([]string, len(podEgressArgs6))
+		copy(podEgressArgs, podEgressArgs6)
+		if iptablesCmdHandler.HasRandomFully() {
+			podEgressArgs = append(podEgressArgs, "--random-fully")
+		}
+
+		err = iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", podEgressArgs...)
+		if err != nil {
+			return errors.New("Failed to add iptables rule to masquerade outbound traffic from pods: " +
+				err.Error() + "External connectivity will not work.")
+
+		}
 	}
 
-	podEgressArgs := podEgressArgs4
-	if nrc.isIpv6 {
-		podEgressArgs = podEgressArgs6
-	}
-	if iptablesCmdHandler.HasRandomFully() {
-		podEgressArgs = append(podEgressArgs, "--random-fully")
-	}
-
-	err = iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", podEgressArgs...)
-	if err != nil {
-		return errors.New("Failed to add iptables rule to masquerade outbound traffic from pods: " +
-			err.Error() + "External connectivity will not work.")
-
-	}
-
-	klog.V(1).Infof("Added iptables rule to masquerade outbound traffic from pods.")
+	klog.V(1).Infof("Added iptables rule(s) to masquerade outbound traffic from pods.")
 	return nil
 }
 
 func (nrc *NetworkRoutingController) deletePodEgressRule() error {
-	iptablesCmdHandler, err := nrc.newIptablesCmdHandler()
-	if err != nil {
-		return errors.New("Failed create iptables handler:" + err.Error())
-	}
-
-	podEgressArgs := podEgressArgs4
-	if nrc.isIpv6 {
-		podEgressArgs = podEgressArgs6
-	}
-	if iptablesCmdHandler.HasRandomFully() {
-		podEgressArgs = append(podEgressArgs, "--random-fully")
-	}
-
-	exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", podEgressArgs...)
-	if err != nil {
-		return errors.New("Failed to lookup iptables rule to masquerade outbound traffic from pods: " + err.Error())
-	}
-
-	if exists {
-		err = iptablesCmdHandler.Delete("nat", "POSTROUTING", podEgressArgs...)
+	if nrc.enableIPv4 {
+		iptablesCmdHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 		if err != nil {
-			return errors.New("Failed to delete iptables rule to masquerade outbound traffic from pods: " +
-				err.Error() + ". Pod egress might still work...")
+			return fmt.Errorf("failed create iptables handler: %w", err)
 		}
-		klog.Infof("Deleted iptables rule to masquerade outbound traffic from pods.")
+
+		podEgressArgs := podEgressArgs4
+		if iptablesCmdHandler.HasRandomFully() {
+			podEgressArgs = append(podEgressArgs, "--random-fully")
+		}
+
+		exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", podEgressArgs...)
+		if err != nil {
+			return errors.New("Failed to lookup iptables rule to masquerade outbound traffic from pods: " + err.Error())
+		}
+
+		if exists {
+			err = iptablesCmdHandler.Delete("nat", "POSTROUTING", podEgressArgs...)
+			if err != nil {
+				return errors.New("Failed to delete iptables rule to masquerade outbound traffic from pods: " +
+					err.Error() + ". Pod egress might still work...")
+			}
+			klog.Infof("Deleted iptables rule to masquerade outbound traffic from pods.")
+		}
+	}
+	if nrc.enableIPv6 {
+		iptablesCmdHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return fmt.Errorf("Failed create iptables handler:" + err.Error())
+		}
+
+		podEgressArgs := podEgressArgs4
+		if iptablesCmdHandler.HasRandomFully() {
+			podEgressArgs = append(podEgressArgs, "--random-fully")
+		}
+
+		exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", podEgressArgs...)
+		if err != nil {
+			return errors.New("Failed to lookup iptables rule to masquerade outbound traffic from pods: " + err.Error())
+		}
+
+		if exists {
+			err = iptablesCmdHandler.Delete("nat", "POSTROUTING", podEgressArgs...)
+			if err != nil {
+				return errors.New("Failed to delete iptables rule to masquerade outbound traffic from pods: " +
+					err.Error() + ". Pod egress might still work...")
+			}
+			klog.Infof("Deleted iptables rule to masquerade outbound traffic from pods.")
+		}
+
 	}
 
 	return nil
 }
 
 func (nrc *NetworkRoutingController) deleteBadPodEgressRules() error {
-	iptablesCmdHandler, err := nrc.newIptablesCmdHandler()
-	if err != nil {
-		return errors.New("Failed create iptables handler:" + err.Error())
-	}
-	podEgressArgsBad := podEgressArgsBad4
-	if nrc.isIpv6 {
-		podEgressArgsBad = podEgressArgsBad6
-	}
+	if nrc.enableIPv4 {
+		iptablesCmdHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
+		if err != nil {
+			return fmt.Errorf("failed create iptables handler: %w", err)
+		}
+		podEgressArgsBad := podEgressArgsBad4
 
-	// If random fully is supported remove the original rule as well
-	if iptablesCmdHandler.HasRandomFully() {
-		if !nrc.isIpv6 {
+		// If random fully is supported remove the original rule as well
+		if iptablesCmdHandler.HasRandomFully() {
 			podEgressArgsBad = append(podEgressArgsBad, podEgressArgs4)
-		} else {
+		}
+
+		for _, args := range podEgressArgsBad {
+			exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
+			if err != nil {
+				return fmt.Errorf("failed to lookup iptables rule: %w", err)
+			}
+
+			if exists {
+				err = iptablesCmdHandler.Delete("nat", "POSTROUTING", args...)
+				if err != nil {
+					return fmt.Errorf("failed to delete old/bad iptables rule to masquerade outbound traffic "+
+						"from pods: %w. Pod egress might still work, or bugs may persist after upgrade", err)
+				}
+				klog.Infof("Deleted old/bad iptables rule to masquerade outbound traffic from pods.")
+			}
+		}
+	}
+	if nrc.enableIPv6 {
+		iptablesCmdHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
+		if err != nil {
+			return fmt.Errorf("failed create iptables handler: %w", err)
+		}
+		podEgressArgsBad := podEgressArgsBad6
+
+		// If random fully is supported remove the original rule as well
+		if iptablesCmdHandler.HasRandomFully() {
 			podEgressArgsBad = append(podEgressArgsBad, podEgressArgs6)
 		}
-	}
 
-	for _, args := range podEgressArgsBad {
-		exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
-		if err != nil {
-			return fmt.Errorf("failed to lookup iptables rule: %s", err.Error())
-		}
-
-		if exists {
-			err = iptablesCmdHandler.Delete("nat", "POSTROUTING", args...)
+		for _, args := range podEgressArgsBad {
+			exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
 			if err != nil {
-				return fmt.Errorf("failed to delete old/bad iptables rule to masquerade outbound traffic "+
-					"from pods: %s. Pod egress might still work, or bugs may persist after upgrade", err)
+				return fmt.Errorf("failed to lookup iptables rule: %w", err)
 			}
-			klog.Infof("Deleted old/bad iptables rule to masquerade outbound traffic from pods.")
+
+			if exists {
+				err = iptablesCmdHandler.Delete("nat", "POSTROUTING", args...)
+				if err != nil {
+					return fmt.Errorf("failed to delete old/bad iptables rule to masquerade outbound traffic "+
+						"from pods: %w. Pod egress might still work, or bugs may persist after upgrade", err)
+				}
+				klog.Infof("Deleted old/bad iptables rule to masquerade outbound traffic from pods.")
+			}
 		}
 	}
 

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -95,7 +95,7 @@ func ipv6IsEnabled() bool {
 	return true
 }
 
-func getNodeSubnet(nodeIP net.IP) (net.IPNet, string, error) {
+func getNodeSubnet(nodeIPv4, nodeIPv6 net.IP, enableIPv4, enableIPv6 bool) (net.IPNet, string, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return net.IPNet{}, "", errors.New("failed to get list of links")
@@ -106,7 +106,10 @@ func getNodeSubnet(nodeIP net.IP) (net.IPNet, string, error) {
 			return net.IPNet{}, "", errors.New("failed to get list of addr")
 		}
 		for _, addr := range addresses {
-			if addr.IPNet.IP.Equal(nodeIP) {
+			if enableIPv4 && addr.IPNet.IP.Equal(nodeIPv4) {
+				return *addr.IPNet, link.Attrs().Name, nil
+			}
+			if enableIPv6 && addr.IPNet.IP.Equal(nodeIPv6) {
 				return *addr.IPNet, link.Attrs().Name, nil
 			}
 		}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -32,6 +32,8 @@ type KubeRouterConfig struct {
 	DisableSrcDstCheck             bool
 	EnableCNI                      bool
 	EnableiBGP                     bool
+	EnableIPv4                     bool
+	EnableIPv6                     bool
 	EnableOverlay                  bool
 	EnablePodEgress                bool
 	EnablePprof                    bool
@@ -83,6 +85,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		CacheSyncTimeout:               1 * time.Minute,
 		ClusterIPCIDR:                  "10.96.0.0/12",
 		EnableOverlay:                  true,
+		EnableIPv4:                     true,
 		IPTablesSyncPeriod:             5 * time.Minute,
 		IpvsGracefulPeriod:             30 * time.Second,
 		IpvsSyncPeriod:                 5 * time.Minute,
@@ -130,6 +133,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin.")
 	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,
 		"Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers")
+	fs.BoolVar(&s.EnableIPv4, "enable-ipv4", true, "Enables IPv4 support")
+	fs.BoolVar(&s.EnableIPv6, "enable-ipv6", true, "Enables IPv6 support")
 	fs.BoolVar(&s.EnableOverlay, "enable-overlay", true,
 		"When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across "+
 			"nodes in different subnets. When set to false no tunneling is used and routing infrastructure is "+

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -44,7 +44,7 @@ func GetNodeObject(clientset kubernetes.Interface, hostnameOverride string) (*ap
 	return nil, fmt.Errorf("failed to identify the node by NODE_NAME, hostname or --hostname-override")
 }
 
-// GetNodeIP returns the most valid external facing IP address for a node.
+// GetNodeIP returns the most valid external facing IP addresses for a node (IPv4 and IPv6).
 // Order of preference:
 // 1. NodeInternalIP
 // 2. NodeExternalIP (Only set on cloud providers usually)


### PR DESCRIPTION
This change allows to define two cluster CIDRs for compatibility with
Kubernetes dual-stuck, with an assumption that two CIDRs are usually
IPv4 and IPv6.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>

---

This is **not** a proper upstream PR. It's definitely not ready for that. Just showing progress and letting my colleagues to review / help / test.